### PR TITLE
Fix: update selected status of current item when switching to select mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -319,9 +319,11 @@ fn run_app(
                         }
                         KeyCode::Char('v') => {
                             app.mode = CursorMode::Select;
+                            after_move(&mut app); // select current selected item
                         }
                         KeyCode::Char('V') => {
                             app.mode = CursorMode::Unselect;
+                            after_move(&mut app); // unselect current selected item
                         }
                         KeyCode::Char('h') => {
                             app.show_help_popup = !app.show_help_popup;


### PR DESCRIPTION
Thank you for providing this tool, it's just what I needed :)
I've made a pull request with small suggestion for improvement.

I suppose it is generally expected that when entering select/deselect mode, the currently selected item will also be selected/deselected.