### PR TITLE
Suppress child process output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::process::Stdio;
 use std::sync::mpsc::SyncSender;
 use std::sync::Arc;
 use std::{error::Error, io};
@@ -274,6 +275,7 @@ fn run_app(
                                             std::process::Command::new("cargo")
                                                 .arg("clean")
                                                 .current_dir(target.project_path.clone())
+                                                .stderr(Stdio::null())
                                                 .spawn()
                                                 .expect("failed to execute process");
                                         }


### PR DESCRIPTION
By running `cargo clean` as a child process, its output may override the UI (like the image below).
Since the output of `cargo` is output to stderr, it seems better to ignore it.

<img width="605" alt="image" src="https://github.com/higumachan/cargo-cleaner/assets/31386431/9ce38105-f7e7-40de-834f-a747452942bc">
